### PR TITLE
Fix for hard coded Clear filter "Cancelar" in demo

### DIFF
--- a/demo/kendo_global.en-US.html
+++ b/demo/kendo_global.en-US.html
@@ -184,11 +184,7 @@
                   data: createRandomData(50),
                   pageSize: 10
               },
-              filterable: {
-                messages: {
-                  clear: "Cancelar"
-                }
-              },
+              filterable: true,
               columnMenu: true,
               groupable: true,
               sortable: true,

--- a/demo/kendo_global.sv-SE.html
+++ b/demo/kendo_global.sv-SE.html
@@ -184,11 +184,7 @@
                   data: createRandomData(50),
                   pageSize: 10
               },
-              filterable: {
-                messages: {
-                  clear: "Cancelar"
-                }
-              },
+              filterable: true,
               columnMenu: true,
               groupable: true,
               sortable: true,


### PR DESCRIPTION
The translation of Clear for the filter was hard coded to "Cancelar" in
the demo. Just fixing the Swedish and US English for now because I am not sure this is an ok fix. Was there a reason for putting

```
filterable: {
  messages: {
    clear: "Cancelar"
  }
},
```

or was it just a mistake?
