### PR TITLE
Change wrong spelling in Turkish language

### DIFF
--- a/lang/kendo.tr-TR.js
+++ b/lang/kendo.tr-TR.js
@@ -2,7 +2,7 @@
 * Kendo UI Localization Project for v2012.3.1114 
 * Copyright 2012 Telerik AD. All rights reserved.
 * 
-* Standard Trukish (tr-TR) Language Pack
+* Standard Turkish (tr-TR) Language Pack
 *
 * Project home  : https://github.com/loudenvier/kendo-global
 * Kendo UI home : http://kendoui.com


### PR DESCRIPTION
In Turkish Language Pack comments there is a wrong spelling of the word "Turkish".

Found it on the government website while applying for a residence permit 😄